### PR TITLE
Prefer includes to contains

### DIFF
--- a/addon/helpers/array-contains.js
+++ b/addon/helpers/array-contains.js
@@ -68,7 +68,7 @@ export default Helper.extend({
     assert('First parameter should be a valid array', isArray(array));
 
     let property = hash ? hash.property : null;
-    let contains = false;
+    let contained = false;
     this.setupRecompute(array, property);
 
     // Wrap into an Ember.Array to use advanced methods while supporting disabling prototype extensions
@@ -77,13 +77,16 @@ export default Helper.extend({
 
     if (property) {
       // Property provided, test the property
-      contains = wrappedArray.isAny(property, value);
+      contained = wrappedArray.isAny(property, value);
     } else {
       // No property provided, test the full object
-      contains = wrappedArray.contains(value);
+
+      // Use includes if it exists (ember >= 2.8), use legacy contains otherwise
+      let containsFct = wrappedArray.includes || wrappedArray.contains;
+      contained = containsFct.call(wrappedArray, value);
     }
 
-    return contains;
+    return contained;
   },
 
   recompute: function () {


### PR DESCRIPTION
Ember 2.8 has deprecated Enumerable#contains in favor of Enumerable#includes to stay in line with standards. see [here](http://emberjs.com/blog/2016/07/25/ember-2-7-and-2-8-beta-released.html#toc_code-enumerable-includes-code-and-code-array-includes-code)

This PR updates the helper to use includes instead of contains if it exists. To ensure backward compatibility with previous ember versions, contains is still used if includes is not defined.

closes #15 