### PR TITLE
chore(package): update version for ember-cli-htmlbars-inline-precompi…

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "deploy": "ember github-pages:commit --message \"Deploy gh-pages from commit $(git rev-parse HEAD)\"; git push; git checkout -"
   },
   "dependencies": {
-    "ember-cli-babel": "^5.1.7",
+    "ember-cli-babel": "^6.1.0",
     "ember-runtime-enumerable-includes-polyfill": "^2.0.0"
   },
   "devDependencies": {
@@ -36,7 +36,7 @@
     "ember-cli-eslint": "^3.0.3",
     "ember-cli-github-pages": "^0.1.2",
     "ember-cli-htmlbars": "^2.0.1",
-    "ember-cli-htmlbars-inline-precompile": "^0.3.6",
+    "ember-cli-htmlbars-inline-precompile": "^0.4.3",
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-mirage": "^0.3.1",
     "ember-cli-mocha": "^0.14.3",


### PR DESCRIPTION
…le and ember-cli-babel

These two libs have to be updated together:
* ember-cli-htmlbars-inline-precompile to 0.4.3
* ember-cli-babel to 6.1.0

closes #88 closes #89 closes #101 closes #105